### PR TITLE
fix gemspec as fluentd offical state to make 1.2.2 compatible

### DIFF
--- a/fluent-plugin-multiline-parser.gemspec
+++ b/fluent-plugin-multiline-parser.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "test-unit"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "thread_safe"
-  gem.add_runtime_dependency "fluentd", "~> 0.12.0"
+  gem.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
 end


### PR DESCRIPTION
ad official website saying:
https://docs.fluentd.org/v1.0/articles/plugin-update-from-v0.12